### PR TITLE
feat(entity): added entity validation to instance props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 2.8.5  - 2021-12-25
+
+---
+
+### Added
+
+- Entity: added method checkProps to entity instance
+
 ### 2.8.4  - 2021-12-24
 
 ---

--- a/example/simple-player-with-validation.entity.ts
+++ b/example/simple-player-with-validation.entity.ts
@@ -29,10 +29,21 @@ export class Player extends Entity<Props> {
 		this.props.updatedAt = new Date();
 	}
 
+	private isRequiredPropsDefined ():boolean {
+		return !this.checkProps( ['userId', 'teamColor'] ).isSome( 'undefined' );
+	}
+
 	public static create(props: Props): Result<Player> {
 		/*
 		 Business Logic Validations Here
 		*/
-		return Result.ok<Player>(new Player(props));
+		const player = new Player( props );
+		const isPropsDefined = player.isRequiredPropsDefined();
+
+		if ( !isPropsDefined ) {
+			return Result.fail( 'userId and teamColor is required' );
+		}
+		
+		return Result.ok<Player>(player);
 	}
 }

--- a/example/tests/simple-player.entity.spec.ts
+++ b/example/tests/simple-player.entity.spec.ts
@@ -65,6 +65,53 @@ describe('simple-player.entity', () => {
 
 		// Create player
 		const player = Player.create({ ID, teamColor, userId });
-		expect(player.isSuccess).toBeTruthy();
+		expect( player.isSuccess ).toBeTruthy();
+		
+	} )
+	
+	it( 'should validate the entity props', () => {
+
+		// 	Create value objects
+		const teamColor = HEXColorValueObject.randomColor();
+		const ID = ShortDomainId.create();
+		const userId = DomainId.create();
+
+		// Create player
+		const player = Player.create( { ID, teamColor, userId } ).getResult();
+		
+		const isInstance = player
+			.checkProps( ['teamColor'] )
+			.isInstanceOf( HEXColorValueObject );
+		
+		expect( isInstance ).toBeTruthy();
+	} )
+	
+	it( 'should validate the entity props', () => {
+
+		// 	Create value objects
+		const teamColor = HEXColorValueObject.randomColor();
+		const ID = ShortDomainId.create();
+		const userId = DomainId.create();
+
+		// Create player
+		const player = Player.create( { ID, teamColor, userId } ).getResult();
+		
+		const isInstance = player
+			.checkProps( ['teamColor', 'userId'] )
+			.isInstanceOf( HEXColorValueObject );
+		
+		expect( isInstance ).toBeFalsy();
+
+		const isAllUndefined = player
+			.checkProps( ['teamColor', 'userId', 'age'] )
+			.isAll('undefined');
+		
+		expect( isAllUndefined ).toBeFalsy();
+
+		const isSomeUndefined = player
+			.checkProps( ['teamColor', 'userId', 'age'] )
+			.isSome('undefined');
+		
+		expect( isSomeUndefined ).toBeTruthy();
 	})
 });

--- a/lib/core/entity.ts
+++ b/lib/core/entity.ts
@@ -7,6 +7,8 @@ import UniqueEntityID from './unique-entity-id';
 import { FactoryMethod } from '../repo/mapper.interface';
 import Result from './result';
 
+type Type = 'undefined' | 'symbol' | 'bigint' | 'boolean' | 'function' | 'number' | 'object' | 'string'
+
 export class DomainEvents {
 	private static handlersMap: any = {};
 	private static markedAggregates: AggregateRoot<any>[] = [];
@@ -193,6 +195,44 @@ abstract class Entity<T extends BaseDomainEntity> {
 	 */
 	get updatedAt(): Date {
 		return this.props.updatedAt ?? new Date();
+	}
+
+	/**
+	 * 
+	 * @param keys Array of entity keys
+	 * @returns methods to check
+	 */
+	checkProps ( keys: Array<keyof T> ) {
+		type KEY = keyof Object;
+		return {
+			/**
+			 * 
+			 * @param type `undefined` `symbol` `bigint` `boolean` `function` `number` `object` `string` as string
+			 * @returns boolean. true if some value has type provided
+			 */
+			isSome: (type: Type): boolean => {
+				const results = keys.map( ( key ) => typeof this.props[key as KEY] !== type );
+				return results.includes( false );
+			},
+			/**
+			 * 
+			 * @param type `undefined` `symbol` `bigint` `boolean` `function` `number` `object` `string` as string
+			 * @returns boolean. true if all value has type provided
+			 */
+			isAll: (type: Type):boolean => {
+				const results = keys.map( ( key ) => typeof this.props[key as KEY] !== type );
+				return !results.includes( true );
+			},
+			/**
+			 * 
+			 * @param prop ValueObject or Entity class
+			 * @returns boolean. true if all values is instance of provided class
+			 */
+			isInstanceOf: (prop: any): boolean => {
+				const results = keys.map( ( key ) => this.props[key as KEY] instanceof prop );
+				return !results.includes( false );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
```ts

	it( 'should validate the entity props', () => {

		// Create value objects
		const teamColor = HEXColorValueObject.randomColor();
		const ID = ShortDomainId.create();
		const userId = DomainId.create();

		// Create player
		const player = Player.create( { ID, teamColor, userId } ).getResult();
		
		const isInstance = player
			.checkProps( ['teamColor', 'userId'] )
			.isInstanceOf( HEXColorValueObject );
		
		expect( isInstance ).toBeFalsy();

		const isAllUndefined = player
			.checkProps( ['teamColor', 'userId', 'age'] )
			.isAll('undefined');
		
		expect( isAllUndefined ).toBeFalsy();

		const isSomeUndefined = player
			.checkProps( ['teamColor', 'userId', 'age'] )
			.isSome('undefined');
		
		expect( isSomeUndefined ).toBeTruthy();
	})

```