### PR TITLE
feat(entity): added method hasSomeTypes to checkProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 2.8.8 - 2021-12-29
+
+---
+### Added
+
+- Entity: hasSomeTypes method to validate different types from instance keys
+
+### Changed 
+
+- Entity: isSome method > new accepted type: 'null'
+- Entity: isAll method > new accepted type: 'null'
+
+
 ### 2.8.7 - 2021-12-28
 
 ---

--- a/example/tests/simple-player.entity.spec.ts
+++ b/example/tests/simple-player.entity.spec.ts
@@ -1,4 +1,4 @@
-import { DomainId, HEXColorValueObject, Result, ShortDomainId, TMapper } from "@types-ddd";
+import { BaseDomainEntity, DateValueObject, DomainId, Entity, HEXColorValueObject, Result, ShortDomainId, TMapper, UserNameValueObject } from "@types-ddd";
 import { Player } from "../simple-player.entity";
 
 describe('simple-player.entity', () => {
@@ -148,5 +148,67 @@ describe('simple-player.entity', () => {
 			teamColor: teamColor.value,
 			userId: userId.uid
 		})
+	} )
+	
+	it( 'should validate different types from aggregate', () => {
+
+		interface Props extends BaseDomainEntity {
+			age?: DateValueObject;
+			userId: ShortDomainId;
+			teamColor: HEXColorValueObject;
+			name?: UserNameValueObject;
+		}
+
+		class Example extends Entity<Props> {
+			private constructor (props: Props) {
+				super( props, Example.name );
+			}
+
+			get age(): DateValueObject | undefined {
+			return this.props.age;
+			};
+			get userId(): ShortDomainId{
+				return this.props.userId;
+			};
+			get teamColor(): HEXColorValueObject {
+				return this.props.teamColor;
+			};
+			get name(): UserNameValueObject | null {
+				return this.props.name ?? null;
+			};
+
+			public static create ( props: Props ): Result<Example> {
+				return Result.ok( new Example( props ) );
+			}
+
+		}
+
+		// 	Create value objects
+		const teamColor = HEXColorValueObject.randomColor();
+		const ID = ShortDomainId.create();
+		const userId = DomainId.create();
+		
+		// Create player
+		const player = Example.create( { ID, teamColor, userId, name: null as any } ).getResult();
+		
+		const isNullable = player.checkProps( ['age'] ).isSome( 'null' );
+		const isUndefined = player.checkProps( ['age'] ).isSome( 'undefined' );
+
+		// is undefined
+		expect( player.age ).toBeUndefined();
+		expect( isNullable ).toBeFalsy();
+		expect( isUndefined ).toBeTruthy();
+
+		const nullableName = player.checkProps( ['name'] ).isSome( 'null' );
+		expect( player.name ).toBeNull();
+		expect( nullableName ).toBeTruthy();
+
+		const typesResult = player.checkProps( ['age', 'name'] ).hasSomeTypes( ['null', 'undefined'] );
+		expect( typesResult ).toBeTruthy();
+
+		const player2 = Example.create( { ID, teamColor, userId, age: null as any } ).getResult();
+
+		const typesResult2 = player2.checkProps( ['age'] ).hasSomeTypes( ['null', 'undefined'] );
+		expect( typesResult2 ).toBeTruthy();
 	})
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "types-ddd",
-	"version": "2.8.7",
+	"version": "2.8.8",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "dist/index.js",
 	"types": "dist/index.d.js",


### PR DESCRIPTION
now its possible validate custom types
#103

Example:

```ts 

	it( 'should validate different types from aggregate', () => {

		interface Props extends BaseDomainEntity {
			age?: DateValueObject;
			userId: ShortDomainId;
			teamColor: HEXColorValueObject;
			name?: UserNameValueObject;
		}

		class Example extends Entity<Props> {
			private constructor (props: Props) {
				super( props, Example.name );
			}

			get age(): DateValueObject | undefined {
			return this.props.age;
			};
			get userId(): ShortDomainId{
				return this.props.userId;
			};
			get teamColor(): HEXColorValueObject {
				return this.props.teamColor;
			};
			get name(): UserNameValueObject | null {
				return this.props.name ?? null;
			};

			public static create ( props: Props ): Result<Example> {
				return Result.ok( new Example( props ) );
			}

		}

		// 	Create value objects
		const teamColor = HEXColorValueObject.randomColor();
		const ID = ShortDomainId.create();
		const userId = DomainId.create();
		
		// Create player
		const player = Example.create( { ID, teamColor, userId, name: null as any } ).getResult();
		
		const isNullable = player.checkProps( ['age'] ).isSome( 'null' );
		const isUndefined = player.checkProps( ['age'] ).isSome( 'undefined' );

		// is undefined
		expect( player.age ).toBeUndefined();
		expect( isNullable ).toBeFalsy();
		expect( isUndefined ).toBeTruthy();

		const nullableName = player.checkProps( ['name'] ).isSome( 'null' );
		expect( player.name ).toBeNull();
		expect( nullableName ).toBeTruthy();

		const typesResult = player.checkProps( ['age', 'name'] ).hasSomeTypes( ['null', 'undefined'] );
		expect( typesResult ).toBeTruthy();

		const player2 = Example.create( { ID, teamColor, userId, age: null as any } ).getResult();

		const typesResult2 = player2.checkProps( ['age'] ).hasSomeTypes( ['null', 'undefined'] );
		expect( typesResult2 ).toBeTruthy();
	})

```