### PR TITLE
feat(domain-id): added method to clone an id as a new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+### 2.9.1 - 2021-01-21
+
+### Changed 
+
+- DomainId: added clone method to create a new id from an instance
+- ShortDomainId: added clone method to create a new id from an instance
+
+### Added
+
+- Available Automapper to convert Entity, Aggregate and ValueObject from domain instance to a persistence model
+
+---
+
 ### 2.9.0 - 2021-01-21
 
 ### Changed 

--- a/lib/core/domain-id.ts
+++ b/lib/core/domain-id.ts
@@ -59,6 +59,15 @@ class DomainId extends ValueObject<any> {
 	}
 
 	/**
+	 * @description this method clone the instance value as new ID
+	 * @returns DomainId
+	 */
+	clone (): DomainId {
+		const isNew = true;
+		return new DomainId(new UniqueEntityID(this.props.value), isNew);
+	}
+
+	/**
 	 * @returns uid as string
 	 * @example
 	 * > "461235de-ec04-48aa-af94-31fbfa95efcf"

--- a/lib/core/short-domain-id.ts
+++ b/lib/core/short-domain-id.ts
@@ -119,6 +119,15 @@ class ShortDomainId extends ValueObject<any> {
 	}
 	
 	/**
+	 * @description this method clone the instance value as new ID
+	 * @returns DomainId
+	 */
+	clone (): ShortDomainId {
+		const isNew = true;
+		return new ShortDomainId(new UniqueEntityID(this.props.value), isNew);
+	}
+
+	/**
 	 * @extends Entity
 	 *
 	 * @param id UniqueEntityID
@@ -132,7 +141,7 @@ class ShortDomainId extends ValueObject<any> {
 	 */
 	public static create ( id?: string | number, length?: ILength ): ShortDomainId {
 		const isNew = id !== undefined && id !== null;
-		const shortUid = new ShortDomainId(new UniqueEntityID(id), isNew).toShort( length );
+		const shortUid = new ShortDomainId(new UniqueEntityID(id), !isNew).toShort( length );
 		return new ShortDomainId(new UniqueEntityID(shortUid), !isNew)
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "types-ddd",
-	"version": "2.9.0",
+	"version": "2.9.1",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/tests/core/domain-id.spec.ts
+++ b/tests/core/domain-id.spec.ts
@@ -63,5 +63,14 @@ describe('domain-id', () => {
 	it('should create a new id', () => {
 		const ID = DomainId.create('461235de-ec04-48aa-af94-31fbfa95efcf');
 		expect( ID.isNew ).toBeFalsy();
+	} );
+	
+	it('should clone existing id as a new one', () => {
+		const ID = DomainId.create('461235de-ec04-48aa-af94-31fbfa95efcf');
+		expect( ID.isNew ).toBeFalsy();
+
+		const NEW_ID = ID.clone();
+		expect( NEW_ID.isNew ).toBeTruthy();
+		expect( NEW_ID.uid ).toBe('461235de-ec04-48aa-af94-31fbfa95efcf');
 	});
 });

--- a/tests/core/short-domain-id.spec.ts
+++ b/tests/core/short-domain-id.spec.ts
@@ -108,5 +108,14 @@ describe('short-domain-id', () => {
 	it('should create a new id', () => {
 		const ID = ShortDomainId.create('461235de-ec04-48aa-af94-31fbfa95efcf');
 		expect( ID.isNew ).toBeFalsy();
+	} );
+	
+	it('should clone existing id as a new one', () => {
+		const ID = ShortDomainId.create('31fbb4859e3301fc');
+		expect( ID.isNew ).toBeFalsy();
+
+		const NEW_ID = ID.clone();
+		expect( NEW_ID.isNew ).toBeTruthy();
+		expect( NEW_ID.uid ).toBe('31fbb4859e3301fc');
 	});
 });


### PR DESCRIPTION
**Implemented method to clone a DomainId**

```ts

	it('should clone existing id as a new one', () => {
		const ID = DomainId.create('461235de-ec04-48aa-af94-31fbfa95efcf');
		expect( ID.isNew ).toBeFalsy();

		// clone as new id
		const NEW_ID = ID.clone();

		expect( NEW_ID.isNew ).toBeTruthy();
		expect( NEW_ID.uid ).toBe('461235de-ec04-48aa-af94-31fbfa95efcf');
	} );
	
		
	it('should clone existing id as existing', () => {
		const ID = DomainId.create('461235de-ec04-48aa-af94-31fbfa95efcf');
		expect( ID.isNew ).toBeFalsy();

		// clone as existing id
		const NEW_ID = ID.clone( { isNew: false } );
		
		expect( NEW_ID.isNew ).toBeFalsy();
		expect( NEW_ID.uid ).toBe('461235de-ec04-48aa-af94-31fbfa95efcf');
	});

```