### PR TITLE
Feat/to object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ---
 
+### 2.9.11 - 2022-02-13
+
+### Changed
+
+- toObject: added support to convert a value object inside another one
+
+---
+
 ### 2.9.9 ~2.9.10 - 2022-02-13
 
 ### Changed

--- a/lib/core/value-object.ts
+++ b/lib/core/value-object.ts
@@ -28,16 +28,54 @@ export default abstract class ValueObject<T extends ValueObjectProps> {
 		const keys = Object.keys(this.props);
 
 		if (keys.length > 1) {
-			valueObj = Object.assign(
-				{},
-				{ ...valueObj },
-				{ ...this?.['props'] }
-			);
+			keys.map((key) => {
+				if (this[key] instanceof ValueObject) {
+					const props = this?.[key].toObject();
+					valueObj = Object.assign(
+						{},
+						{ ...valueObj },
+						{ [key]: props }
+					);
+				} else {
+					if (Array.isArray(this[key])) {
+						const isValueObject =
+							this[key][0] instanceof ValueObject;
+
+						if (isValueObject) {
+							const props = this[key].map(
+								(vo: ValueObject<any>) => vo?.toObject()
+							);
+							valueObj = Object.assign(
+								{},
+								{ ...valueObj },
+								{ [key]: props }
+							);
+						} else {
+							valueObj = Object.assign(
+								{},
+								{ ...valueObj },
+								{ [key]: this.props[key] }
+							);
+						}
+					} else {
+						valueObj = Object.assign(
+							{},
+							{ ...valueObj },
+							{ [key]: this.props[key] }
+						);
+					}
+				}
+			});
 
 			return valueObj as Readonly<D[keyof D]>;
 		}
 
 		valueObj = this?.[keys[0]];
+
+		if (valueObj instanceof ValueObject) {
+			valueObj = valueObj.toObject();
+		}
+
 		return valueObj as Readonly<D[keyof D]>;
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "types-ddd",
-	"version": "2.9.10",
+	"version": "2.9.11",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/tests/repo/auto-mapper.spec.ts
+++ b/tests/repo/auto-mapper.spec.ts
@@ -13,10 +13,39 @@ import {
 	DomainId,
 	ValueObject,
 	CustomStringValueObject,
+	Logger,
 } from '@types-ddd';
 import { User } from '../../example/simple-user.aggregate';
 
 describe('auto-mapper', () => {
+	interface Props {
+		password: PasswordValueObject;
+		coin: CurrencyValueObject;
+		emails: EmailValueObject[];
+	}
+
+	class ComplexValueObject extends ValueObject<Props> {
+		private constructor(props: Props) {
+			super(props);
+		}
+
+		get password(): PasswordValueObject {
+			return this.props.password;
+		}
+
+		get coin(): CurrencyValueObject {
+			return this.props.coin;
+		}
+
+		get emails(): EmailValueObject[] {
+			return this.props.emails;
+		}
+
+		public static create(props: Props): Result<ComplexValueObject> {
+			return Result.ok(new ComplexValueObject(props));
+		}
+	}
+
 	interface SocialInfoVOProps {
 		links: string[];
 		publicEmail?: string;
@@ -125,6 +154,25 @@ describe('auto-mapper', () => {
 			return Result.ok(new SEntity(props));
 		}
 	}
+
+	const currencyVo = CurrencyValueObject.create({
+		currency: 'USD',
+		value: 1000,
+	}).getResult();
+
+	const emailsVo = [
+		'valid1@domain.com',
+		'valid2@domain.com',
+		'valid3@domain.com',
+	].map((email) => EmailValueObject.create(email).getResult());
+
+	const passwordVo = PasswordValueObject.create('eb6@18#R7&').getResult();
+
+	const complexValueObject = ComplexValueObject.create({
+		coin: currencyVo,
+		emails: emailsVo,
+		password: passwordVo,
+	}).getResult();
 
 	it('should get all keys from entity', () => {
 		const date = new Date('2020-01-01T03:00:00.000Z');
@@ -363,5 +411,101 @@ describe('auto-mapper', () => {
 		const result = postEntity.toObject();
 
 		expect(result).toEqual(expectedResult);
+	});
+
+	it('should convert sub-value object in a value object', () => {
+		const result = complexValueObject.toObject();
+
+		Logger.warn(result as any);
+		expect(result).toBeDefined();
+		expect(result).toMatchInlineSnapshot(`
+		Object {
+		  "coin": Object {
+		    "currency": "USD",
+		    "value": 1000,
+		  },
+		  "emails": Array [
+		    "valid1@domain.com",
+		    "valid2@domain.com",
+		    "valid3@domain.com",
+		  ],
+		  "password": "eb6@18#R7&",
+		}
+	`);
+	});
+
+	it('should convert complex value object from an entity', () => {
+		const userName = UserNameValueObject.create('Jane Austin').getResult();
+		const currentDate = new Date('2020-01-01 00:00:00');
+
+		interface Props extends BaseDomainEntity {
+			name: UserNameValueObject;
+			complexVo: ComplexValueObject;
+		}
+
+		class User extends Entity<Props> {
+			private constructor(props: Props) {
+				super(props, User.name);
+			}
+
+			get complexVo(): ComplexValueObject {
+				return this.props.complexVo;
+			}
+
+			get name(): UserNameValueObject {
+				return this.props.name;
+			}
+
+			public static create(props: Props): Result<User> {
+				// ... do some stuff or validation
+				return Result.ok(new User(props));
+			}
+		}
+
+		const user = User.create({
+			ID: DomainId.create('valid_id'),
+			complexVo: complexValueObject,
+			name: userName,
+			createdAt: currentDate,
+			updatedAt: currentDate,
+		}).getResult();
+
+		const obj = user.toObject();
+
+		expect(obj.complexVo).toEqual({
+			coin: {
+				currency: 'USD',
+				value: 1000,
+			},
+			emails: [
+				'valid1@domain.com',
+				'valid2@domain.com',
+				'valid3@domain.com',
+			],
+			password: 'eb6@18#R7&',
+		});
+
+		expect(obj).toMatchInlineSnapshot(`
+		Object {
+		  "complexVo": Object {
+		    "coin": Object {
+		      "currency": "USD",
+		      "value": 1000,
+		    },
+		    "emails": Array [
+		      "valid1@domain.com",
+		      "valid2@domain.com",
+		      "valid3@domain.com",
+		    ],
+		    "password": "eb6@18#R7&",
+		  },
+		  "createdAt": 2020-01-01T00:00:00.000Z,
+		  "deletedAt": undefined,
+		  "id": "valid_id",
+		  "isDeleted": false,
+		  "name": "Jane Austin",
+		  "updatedAt": 2020-01-01T00:00:00.000Z,
+		}
+	`);
 	});
 });


### PR DESCRIPTION
# Auto Mapper
## Added suport to convert nested value object (a value object inside another one)
requires the same key name and value defined on Props keep the same on class getters

```ts

interface Props {
    password: PasswordValueObject;
    coin: CurrencyValueObject;
    emails: EmailValueObject[];
}

class ComplexValueObject extends ValueObject<Props> {
    private constructor(props: Props) {
	    super(props);
    }

    get password(): PasswordValueObject {
	    return this.props.password;
    }
    
    get coin(): CurrencyValueObject {
	    return this.props.coin;
    }
    
    get emails(): EmailValueObject[] {
	    return this.props.emails;
    }
    
    public static create(props: Props): Result<ComplexValueObject> {
	    return Result.ok(new ComplexValueObject(props));
    }
}

```

### create instance 

```ts

import { CurrencyValueObject, EmailValueObject, PasswordValueObject } from 'types-ddd';

const emailsText = [  'valid1@domain.com', 'valid2@domain.com', 'valid3@domain.com' ];

const coin = CurrencyValueObject.create({ currency: 'USD', value: 1000 }).getResult();

const emails = emailsText.map((email) => EmailValueObject.create(email).getResult());

const password = PasswordValueObject.create('eb6@18#R7&').getResult();

const complexValueObject = ComplexValueObject.create({ coin,  emails, password }).getResult();

```

### convert to simple object 

```ts

const obj = complexValueObject.toObject();

console.log(obj);
`{
    "coin":  {
        "currency": "USD",
        "value": 1000,
    },
    "emails":  [
        "valid1@domain.com",
        "valid2@domain.com",
        "valid3@domain.com",
    ],
    "password": "eb6@18#R7&",
`}

```