### PR TITLE
fix(auto-mapper): added suport to convert a simple object on entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ---
 
+### 2.9.13 - 2022-02-14
+
+### Fixed
+
+- toObject: added support to convert a simple object on entity
+
+---
+
 ### 2.9.11 ~ 2.9.12 - 2022-02-13
 
 ### Changed

--- a/lib/core/entity.ts
+++ b/lib/core/entity.ts
@@ -192,7 +192,8 @@ export const convertEntity = <T extends DefaultProps>(target: T): any => {
 		if (
 			typeof subTarget === 'boolean' ||
 			typeof subTarget === 'number' ||
-			typeof subTarget === 'string'
+			typeof subTarget === 'string' ||
+			subTarget instanceof Date
 		) {
 			object = Object.assign({}, { ...object }, { [key]: subTarget });
 		}
@@ -250,7 +251,7 @@ export const convertEntity = <T extends DefaultProps>(target: T): any => {
 						);
 					} else {
 						const subKeys = subTarget.map((obj) => obj?.toObject());
-						Logger.warn(subKeys as any);
+
 						object = Object.assign(
 							{},
 							{ ...object },
@@ -265,6 +266,14 @@ export const convertEntity = <T extends DefaultProps>(target: T): any => {
 					);
 				}
 			} else {
+				object = Object.assign({}, { ...object }, { [key]: subTarget });
+			}
+		}
+
+		const isObject = typeof subTarget === 'object';
+
+		if (isObject && !isArray && !(subTarget instanceof Date)) {
+			if (subTarget?.['props'] === undefined) {
 				object = Object.assign({}, { ...object }, { [key]: subTarget });
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "types-ddd",
-	"version": "2.9.12",
+	"version": "2.9.13",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION


```ts

const ID = DomainId.create('some_valid_id');
const currentDate = new Date('2022-01-01 00:00:00');
const emailVo = EmailValueObject.create('valid_email@domain.com').getResult();
const coinVo = CurrencyValueObject.create({ currency: 'BRL', value: 1000 }).getResult();
const passVo = PasswordValueObject.create('123@#abcABC').getResult();

interface IAddress {
    streetNumber: number;
}

interface ComplexEntityProps extends BaseDomainEntity {
    password: PasswordValueObject;
    coin: CurrencyValueObject;
    emails: EmailValueObject[];
    isPublic: boolean;
    address?: IAddress;
}

const complexEntityOrError = ComplexEntity.create({
    ID,
    emails: [emailVo],
    coin: coinVo,
    password: passVo.
    createdAt: currentDate,
    updatedAt: currentDate,
    isDeleted: false,
    deletedAt: currentDate,
    isPublic: false,
    address: { streetNumber: 20 },
});

const complexEntity = complexEntityOrError.getResult();
const object = complexEntity.toObject();

console.log(object);
`
{
    "address":  {
        "streetNumber": 20,
    },
    "coin":  {
        "currency": "BRL",
        "value": 1000,
    },
    "createdAt": 2022-01-01T00:00:00.000Z,
    "deletedAt": 2022-01-01T00:00:00.000Z,
    "emails":  [ "valid_email@domain.com" ],
    "id": "some_valid_id",
    "isDeleted": false,
    "isPublic": false,
    "password": "123@#abcABC",
    "updatedAt": 2022-01-01T00:00:00.000Z,
}
`

```