### PR TITLE
feat(result): added shortcut for ok and fail from result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ---
+### 3.2.0 - 2022-09-26
+
+### Added
+
+- update deps: rich-domain
+- feat: implement function Fail 
+- feat: implement function Ok
+
+---
 ### 3.1.5 - 2022-09-26
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,22 @@ IResult<A, B, C>;
 
 ```
 
+Alternative shortcuts
+
+```ts
+
+import { Ok, Fail } from 'types-ddd';
+
+// Success use case
+
+return Ok<string>('success message');
+
+// Failure use case
+
+return Fail('error message here');
+
+```
+
 Example how to use generic types.
 First let's create our interfaces to use as generic type.
 - The type of data to be retrieved can be any type you want.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "types-ddd",
-	"version": "3.1.5",
+	"version": "3.2.0",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/tests/utils/result.spec.ts
+++ b/tests/utils/result.spec.ts
@@ -1,0 +1,17 @@
+import { Fail, Ok } from '../../lib';
+
+describe('result', () => {
+	describe('fail', () => {
+		it('should create a fail', () => {
+			const result = Fail('error message');
+			expect(result.isFail()).toBeTruthy();
+		});
+	});
+
+	describe('should create ok', () => {
+		it('should create success', () => {
+			const result = Ok(null);
+			expect(result.isOk()).toBeTruthy();
+		});
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,10 +688,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.18.tgz#633184f55c322e4fb08612307c274ee6d5ed3154"
   integrity sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==
 
-"@types/node@^18.7.14":
-  version "18.7.22"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.22.tgz#76f7401362ad63d9d7eefa7dcdfa5fcd9baddff3"
-  integrity sha512-TsmoXYd4zrkkKjJB0URF/mTIKPl+kVcbqClB2F/ykU7vil1BfWZVndOnpEIozPv4fURD28gyPFeIkW2G+KXOvw==
+"@types/node@^18.7.22":
+  version "18.7.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.23.tgz#75c580983846181ebe5f4abc40fe9dfb2d65665f"
+  integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
 
 "@types/pino@^7.0.5":
   version "7.0.5"
@@ -3120,7 +3120,7 @@ pino@*:
     sonic-boom "^3.1.0"
     thread-stream "^2.0.0"
 
-pino@^8.4.2:
+pino@^8.6.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/pino/-/pino-8.6.0.tgz#b82132965b1549d617b02b7d4e29da7c68ae0361"
   integrity sha512-gCEOs6XpgiM8mSFjiLXQejDJ1PZww8AUmHowQ16QpqpXQDIm3mFwn/29+Y6CJxd6i+x3uXduuerjq+IqWoABbA==
@@ -3384,9 +3384,9 @@ rfdc@^1.3.0:
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
 rich-domain@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/rich-domain/-/rich-domain-1.12.0.tgz#03de7bd25b15f2c6abb869fdfc33a91a88276242"
-  integrity sha512-cBPvJYXK5iGGvYXiHi5m4ANIQrQf9/wYZhNn6VHer8c6no0YmHjxsUYoICFbNz4ztNA7Erd9enLP6THFMRAeXg==
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/rich-domain/-/rich-domain-1.13.0.tgz#0f4691e9a65822714eb06d1818409f0dd5a4cfac"
+  integrity sha512-H77TRkgEpnoV79kLLmdspH9VHR5ydf5cEJt3SjUTL0VIPUPb9IR1zSizC0ZOxhWbc5AgIw/v87gz7dLjWnGTaQ==
 
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
now you can import Ok and Fail from core

```ts

import { Ok, Fail } from 'types-ddd';

// Success use case

return Ok<string>('success message');

// Failure use case

return Fail('error message here');

```

#181

implemented on core pull request [#12](https://github.com/4lessandrodev/rich-domain/pull/12)

Follow C# reference on dotnet 

Reference [dotnet reference](https://learn.microsoft.com/en-us/dotnet/api/system.web.http.apicontroller.ok?view=aspnetcore-2.2)
