### PR TITLE
refactor(result): changes generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,90 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ---
+### 3.2.1 - 2022-09-26
+
+### Changed
+
+- update deps: rich-domain
+
+
+- refactor: Fail
+- refactor: Ok
+- refactor: Result.Ok
+- refactor: Result.fail
+
+Change generic types order for `Result.fail` and `Result.Ok`
+
+Now each method has your own order
+Example: 
+
+```ts
+
+// for implementation: 
+IResult<Payload, Error, MetaData>;
+
+// before the generic order was the same for both method.
+// now for 
+Result.Ok
+
+// the generic order is 
+Result.Ok<Payload, MetaData, Error>(payload metaData);
+
+// for 
+Result.fail 
+
+//the generic order is 
+Result.fail<Error, MetaData, Payload>(error, metaData);
+
+```
+
+Changes made on Ok
+
+```ts
+
+import { Ok } from 'rich-domain';
+
+// simple use case for success. no arg required
+return Ok();
+
+// arg required 
+
+return Ok<string>('my payload');
+
+// arg and metaData required 
+
+interface MetaData {
+  arg: string;
+}
+
+return Ok<string, MetaData>('payload', { arg: 'sample' });
+
+```
+
+Changes made on Fail
+
+```ts
+
+import { Fail } from 'rich-domain';
+
+// simple use case for success. no arg required
+return Fail();
+
+// arg required 
+
+return Fail<string>('my payload');
+
+// arg and metaData required 
+
+interface MetaData {
+  arg: string;
+}
+
+return Fail<string, MetaData>('payload', { arg: 'sample' });
+
+```
+
+---
 ### 3.2.0 - 2022-09-26
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,10 @@ import { Ok, Fail } from 'types-ddd';
 
 // Success use case
 
+return Ok();
+
+// OR 
+
 return Ok<string>('success message');
 
 // Failure use case

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"bcrypt": "^5.0.1",
 		"pino": "^8.6.0",
 		"pino-pretty": "^9.0.0",
-		"rich-domain": "^1.12.0"
+		"rich-domain": "^1.14.0"
 	},
 	"devDependencies": {
 		"@microsoft/tsdoc": "^0.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -683,12 +683,16 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-
-"@types/node@*", "@types/node@^18.7.22":
+"@types/node@*":
   version "18.7.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.22.tgz#76f7401362ad63d9d7eefa7dcdfa5fcd9baddff3"
   integrity sha512-TsmoXYd4zrkkKjJB0URF/mTIKPl+kVcbqClB2F/ykU7vil1BfWZVndOnpEIozPv4fURD28gyPFeIkW2G+KXOvw==
-  
+
+"@types/node@^18.7.22":
+  version "18.7.23"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.23.tgz#75c580983846181ebe5f4abc40fe9dfb2d65665f"
+  integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
+
 "@types/pino@^7.0.5":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/pino/-/pino-7.0.5.tgz#1c84a81b924a6a9e263dbb581dffdbad7a3c60c4"
@@ -3379,10 +3383,10 @@ rfdc@^1.3.0:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
-rich-domain@^1.12.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/rich-domain/-/rich-domain-1.13.0.tgz#0f4691e9a65822714eb06d1818409f0dd5a4cfac"
-  integrity sha512-H77TRkgEpnoV79kLLmdspH9VHR5ydf5cEJt3SjUTL0VIPUPb9IR1zSizC0ZOxhWbc5AgIw/v87gz7dLjWnGTaQ==
+rich-domain@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/rich-domain/-/rich-domain-1.14.0.tgz#60325d2ae5f4f5e7c6dba02af9ee462bcc3eae5a"
+  integrity sha512-GmPFRlSTm1vz03ZdTLfRpvVpMnGQJrlBIjRiLdi9S4mOUZ1cyTm/uWOpBOourlk6ozK+o+pSEaYcQC2eV2ZKHQ==
 
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION

- refactor: Fail
- refactor: Ok
- refactor: Result.Ok
- refactor: Result.fail

Change generic types order for `Result.fail` and `Result.Ok`

Now each method has your own order
Example: 

```ts

// for implementation: 
IResult<Payload, Error, MetaData>;

// before the generic order was the same for both method.
// now for 
Result.Ok

// the generic order is 
Result.Ok<Payload, MetaData, Error>(payload metaData);

// for 
Result.fail 

//the generic order is 
Result.fail<Error, MetaData, Payload>(error, metaData);

```

Changes made on Ok

```ts

import { Ok } from 'rich-domain';

// simple use case for success. no arg required
return Ok();

// arg required 

return Ok<string>('my payload');

// arg and metaData required 

interface MetaData {
  arg: string;
}

return Ok<string, MetaData>('payload', { arg: 'sample' })
```

Changes made on Fail

```ts

import { Fail } from 'rich-domain';

// simple use case for success. no arg required
return Fail();

// arg required 

return Fail<string>('my payload');

// arg and metaData required 

interface MetaData {
  arg: string;
}

return Fail<string, MetaData>('payload', { arg: 'sample' })
```