### PR TITLE
fix(utils): remove empty space from user-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 3.4.1 - 2023-01-03
+
+### Fix
+
+- user-name.value-object: remove empty spaces. By: [VinnyLima](https://github.com/VinnyLima)
+
+---
 ### 3.4.0 - 2022-12-25
 
 ### Update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "types-ddd",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"description": "This package provide utils file and interfaces to assistant build a complex application with domain driving design",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -10,6 +10,10 @@
 		{
 			"name": "Marko Zlatar",
 			"url": "https://github.com/mark01zlatar"
+		},
+		{
+			"name": "Paulo Vinicius",
+			"url": "https://github.com/VinnyLima"
 		}
 	],
 	"engines": {


### PR DESCRIPTION

### 3.4.1 - 2023-01-03

### Fix

- user-name.value-object: remove empty spaces. By: [VinnyLima](https://github.com/VinnyLima)