### PR TITLE
feat: add methods remover caracters specials and return only numbers

### DIFF
--- a/lib/utils/custom-string.value-object.ts
+++ b/lib/utils/custom-string.value-object.ts
@@ -63,6 +63,20 @@ export class CustomStringValueObject extends ValueObject<Prop> {
 	}
 
 	/**
+	 * @returns value without special chars as string
+	 */
+	get removeSpecialChars(): string {
+		return this.props.value.replace(/[^a-zA-Z0-9]/g, '');
+	}
+
+	/**
+	 * @returns value only numbers as string
+	 */
+	get onlyNumbers(): string {
+		return this.props.value.replace(/\D/g, '');
+	}
+
+	/**
 	 * @returns validation
 	 * @method VALIDATOR: function (value: string): boolean;
 	 * @property

--- a/tests/utils/custom-string.value-object.spec.ts
+++ b/tests/utils/custom-string.value-object.spec.ts
@@ -63,6 +63,19 @@ describe('custom-string.value-object', () => {
 		expect(validation.MAX_LENGTH).toBeDefined();
 		expect(validation.MIN_LENGTH).toBeDefined();
 	});
+
+	it('should be get string only numbers', () => {
+		const valueObject =
+			CustomStringValueObject.create('B2D05E00').value().onlyNumbers;
+		expect(valueObject).toBe('20500');
+	});
+
+	it('should be get string without chars especial', () => {
+		const valueObject = CustomStringValueObject.create(
+			'===[brazil(*-*)free]==='
+		);
+		expect(valueObject.value().removeSpecialChars).toBe('brazilfree');
+	});
 });
 
 describe('custom validation', () => {


### PR DESCRIPTION
There was a need for methods to clean up the special characters in a string and return only the numbers, it would be interesting if these two methods were implemented.

This solution for issue: #223 